### PR TITLE
Added ability for custom HSTS header

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Other tags than `daily` are built weekly. For security reasons, you should occas
 - **DB_USER** : username for database *(default : none)*
 - **DB_PASSWORD** : password for database user *(default : none)*
 - **DB_HOST** : database host *(default : none)*
+- **HSTS** : custom HSTS header in the nginx configuration. Empty will disable HSTS *(default: add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;)*
 
 Don't forget to use a **strong password** for the admin account!
 

--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -4,7 +4,7 @@ server {
         
         fastcgi_buffers 64 4K;
         
-        add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+        <HSTS>
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;
@@ -58,7 +58,7 @@ server {
         location ~* \.(?:css|js)$ {
             try_files $uri /index.php$uri$is_args$args;
             add_header Cache-Control "public, max-age=7200";
-            add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+            <HSTS>
             add_header X-Frame-Options "SAMEORIGIN";
             add_header X-Content-Type-Options nosniff;
             add_header X-XSS-Protection "1; mode=block";

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -1,12 +1,20 @@
 #!/bin/sh
 
+# Set HSTS headers
+HSTS='add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";'
+if  [ ! -z "${CUSTOM_HSTS+set}" ];then
+  HSTS="$CUSTOM_HSTS"
+fi
+
 sed -i -e "s/<APC_SHM_SIZE>/$APC_SHM_SIZE/g" /php/conf.d/apcu.ini \
        -e "s/<OPCACHE_MEM_SIZE>/$OPCACHE_MEM_SIZE/g" /php/conf.d/opcache.ini \
        -e "s/<CRON_MEMORY_LIMIT>/$CRON_MEMORY_LIMIT/g" /etc/s6.d/cron/run \
        -e "s/<CRON_PERIOD>/$CRON_PERIOD/g" /etc/s6.d/cron/run \
        -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /usr/local/bin/occ \
        -e "s/<UPLOAD_MAX_SIZE>/$UPLOAD_MAX_SIZE/g" /nginx/conf/nginx.conf /php/etc/php-fpm.conf \
-       -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /php/etc/php-fpm.conf
+       -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /php/etc/php-fpm.conf \
+       -e "s/<HSTS>/$HSTS/g" /nginx/sites-enabled/nginx.conf
+
 
 # Put the configuration and apps into volumes
 ln -sf /config/config.php /nextcloud/config/config.php &>/dev/null


### PR DESCRIPTION
Added "CUSTOM_HSTS" environment variable to control the HSTS header in the nginx config.

I use this together with jwilder/nginx setup which already uses HSTS without "includeSubdomains" which fits much better in my setup, as I have a bunch of subdomains that do not support HTTPS.

Maybe you think the naming here is a little weird, it is because jwilder/nginx uses "HSTS" variable to override too, so in my setup having "HSTS" as the name would cancel any change.

Any thoughts?