### PR TITLE
Fix non-existent nginx-php tag.

### DIFF
--- a/Dockerfile.daily
+++ b/Dockerfile.daily
@@ -1,4 +1,4 @@
-FROM wonderfall/nginx-php:7.1
+FROM wonderfall/nginx-php:7.2
 
 ENV UID=991 GID=991 \
     UPLOAD_MAX_SIZE=10G \


### PR DESCRIPTION
Your Dockerfile.daily file is referencing wonderfall/ngix-php:7.1 which doesn't exist anymore. This just updates it to 7.2 like your Dockerfile.13.0.

You might want to consider using docker hub automated builds from github. They're free for public repos and you'd see this kind of failure immediately. Just a thought. :)