### PR TITLE
add_header Referrer-Policy "no-referrer" always

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -12,6 +12,7 @@ server {
         add_header X-Robots-Tag none;
         add_header X-Download-Options noopen;
         add_header X-Permitted-Cross-Domain-Policies none;
+        add_header Referrer-Policy "no-referrer" always;
 
         location = /robots.txt {
             allow all;

--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -3,8 +3,10 @@ server {
         root /nextcloud;
         
         fastcgi_buffers 64 4K;
-        
+
+        # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html?highlight=security#enable-http-strict-transport-security
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+        # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html?highlight=security#serve-security-related-headers-by-the-web-server
         add_header X-Content-Type-Options nosniff;
         add_header X-XSS-Protection "1; mode=block";
         add_header X-Robots-Tag none;


### PR DESCRIPTION
Found a complaint on the "Security & setup warnings" after upgrading to nextcloud 14:
`The "Referrer-Policy" HTTP header is not set to "no-referrer", "no-referrer-when-downgrade", "strict-origin" or "strict-origin-when-cross-origin". This can leak referer information. See the W3C Recommendation.`

This complaint is fixed by this PR.

- added links to owncloud documentation 
- added "add_header Referrer-Policy "no-referrer" always;" as per official docs