### PR TITLE
Fix delivery of woff2 file in nginx

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -58,7 +58,7 @@ server {
             index index.php;
         }
 
-        location ~* \.(?:css|js)$ {
+        location ~* \.(?:css|js|woff2?|svg|gif)$ {
             try_files $uri /index.php$uri$is_args$args;
             add_header Cache-Control "public, max-age=7200";
             add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
@@ -71,7 +71,7 @@ server {
             access_log off;
         }
 
-        location ~* \.(?:svg|gif|png|html|ttf|woff|ico|jpg|jpeg)$ {
+        location ~* \.(?:png|html|ttf|ico|jpg|jpeg)$ {
             try_files $uri /index.php$uri$is_args$args;
             access_log off;
         }


### PR DESCRIPTION
https://docs.nextcloud.com/server/15/admin_manual/installation/nginx.html, v14 and v13 has configuration examples for woff2 files. the overview in nextcloud 15 har started to complain about not delivering woff2 files correct. This commit fixes this issue.