### PR TITLE
Resolve #39 - add large_client_header_buffers to nginx.conf

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -3,6 +3,7 @@ server {
         root /nextcloud;
         
         fastcgi_buffers 64 4K;
+        large_client_header_buffers 4 16k;
 
         # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html?highlight=security#enable-http-strict-transport-security
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";


### PR DESCRIPTION
Crap I accidentally hit enter. This pull request fixes issue #39 . I added large_client_header_buffers 4 16k to the main nginx conf file. The official nextcloud docker example files include this line in their nginx.conf.

:+1: 