### PR TITLE
Fix security issue CVE-2019-11043

### DIFF
--- a/Dockerfile.14.0
+++ b/Dockerfile.14.0
@@ -1,4 +1,4 @@
-FROM wonderfall/nginx-php:7.2
+FROM wonderfall/nginx-php:7.2.24
 
 ARG NEXTCLOUD_VERSION=14.0.12
 ARG GPG_nextcloud="2880 6A87 8AE4 23A2 8372  792E D758 99B9 A724 937A"

--- a/Dockerfile.15.0
+++ b/Dockerfile.15.0
@@ -1,4 +1,4 @@
-FROM wonderfall/nginx-php:7.2
+FROM wonderfall/nginx-php:7.2.24
 
 ARG NEXTCLOUD_VERSION=15.0.8
 ARG GPG_nextcloud="2880 6A87 8AE4 23A2 8372  792E D758 99B9 A724 937A"

--- a/Dockerfile.16.0
+++ b/Dockerfile.16.0
@@ -1,4 +1,4 @@
-FROM wonderfall/nginx-php:7.2
+FROM wonderfall/nginx-php:7.2.24
 
 ARG NEXTCLOUD_VERSION=16.0.1
 ARG GPG_nextcloud="2880 6A87 8AE4 23A2 8372  792E D758 99B9 A724 937A"

--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -30,7 +30,7 @@ server {
         }
 
         location / {
-            rewrite ^ /index.php$uri;
+            rewrite ^ /index.php;
         }
 
         location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)/ {
@@ -44,6 +44,7 @@ server {
         location ~ ^/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
             include /nginx/conf/fastcgi_params;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
+            try_files $fastcgi_script_name =404;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PATH_INFO $fastcgi_path_info;
             fastcgi_param modHeadersAvailable true;


### PR DESCRIPTION
- update php version to 7.2.24 (**Warning**: it needs to be build)
- fix nginx configuration

[https://nextcloud.com/blog/urgent-security-issue-in-nginx-php-fpm/]()