### PR TITLE
Use proxy forwarded headers if available for /.well-known redirects

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -1,7 +1,17 @@
+map $http_x_forwarded_port $nc_port {
+  default "$http_x_forwarded_port";
+  ''      "$server_port";
+}
+
+map $http_x_forwarded_proto $nc_proto {
+  default "$http_x_forwarded_proto";
+  ''      "$scheme";
+}
+
 server {
         listen 8888;
         root /nextcloud;
-        
+
         fastcgi_buffers 64 4K;
         fastcgi_hide_header X-Powered-By;
         large_client_header_buffers 4 16k;
@@ -22,11 +32,11 @@ server {
         }
 
         location = /.well-known/carddav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $nc_proto://$host:$nc_port/remote.php/dav;
         }
-    
+
         location = /.well-known/caldav {
-            return 301 $scheme://$host:$server_port/remote.php/dav;
+            return 301 $nc_proto://$host:$nc_port/remote.php/dav;
         }
 
         location / {


### PR DESCRIPTION
Add mapping for X-Forwarded-Proto and X-Forwarded-Port, use these mappings in /.well-known redirects for CalDAV and CardDAV

Resolves issues when container is behind reverse proxy (in case proxy sets properly forwarded headers):
Your web server is not properly set up to resolve "/.well-known/carddav".
Your web server is not properly set up to resolve "/.well-known/caldav".