### PR TITLE
Add exception rule for snuffleupagus

### DIFF
--- a/rootfs/usr/local/etc/php/snuffleupagus/nextcloud-php8.rules
+++ b/rootfs/usr/local/etc/php/snuffleupagus/nextcloud-php8.rules
@@ -1,7 +1,7 @@
 # This is the default configuration file for Snuffleupagus (https://snuffleupagus.rtfd.io),
 # for php8.
 # It contains "reasonable" defaults that won't break your websites,
-# and a lot of commented directives that you can enable if you want to 
+# and a lot of commented directives that you can enable if you want to
 # have a better protection.
 
 # Harden the PRNG
@@ -34,7 +34,7 @@ sp.sloppy_comparison.enable();
 # https://snuffleupagus.readthedocs.io/features.html#protection-against-cross-site-request-forgery
 sp.cookie.name("PHPSESSID").samesite("lax");
 
-# Nextcloud whitelist (tested with Nextcloud 23.0.2)
+# Nextcloud whitelist (tested with Nextcloud 24.0.0)
 sp.disable_function.function("function_exists").param("function").value("proc_open").filename("/nextcloud/3rdparty/symfony/console/Terminal.php").allow();
 sp.disable_function.function("proc_open").filename("/nextcloud/3rdparty/symfony/console/Terminal.php").allow();
 sp.disable_function.function("ini_set").param("option").value_r("display_errors").filename("/nextcloud/lib/base.php").allow();
@@ -43,6 +43,7 @@ sp.disable_function.function("function_exists").param("function").value("exec").
 sp.disable_function.function("ini_get").param("option").value_r("suhosin").filename("/nextcloud/3rdparty/bantu/ini-get-wrapper/src/IniGetWrapper.php").allow();
 sp.disable_function.function("ini_get").param("option").value("open_basedir").filename("/nextcloud/apps2/twofactor_webauthn/vendor/symfony/process/ExecutableFinder.php").allow();
 sp.disable_function.function("ini_get").param("option").value("open_basedir").filename("/nextcloud/3rdparty/symfony/process/ExecutableFinder.php").allow();
+sp.disable_function.function("ini_get").param("option").value("allow_url_fopen").filename("/nextcloud/3rdparty/guzzlehttp/guzzle/src/Utils.php").allow();
 
 # Harden the `chmod` function (0777 (oct = 511, 0666 = 438)
 sp.disable_function.function("chmod").param("permissions").value("438").drop();


### PR DESCRIPTION
Not sure if this is only needed for Nextcloud >= 24, because I just enabled snuffleupagus at my fork and directly updated it to version 24. But this exception rule was needed for most of the `occ` commands (e.g. `occ db:add-missing-indices`).